### PR TITLE
Add CSV upload logic to dashboard

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,16 +1,31 @@
-import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
+"use client";
+
+import { useState } from "react";
+import FileUpload from "@/components/FileUpload";
+import MockDashboard from "@/components/MockDashboard";
+import { parseAndValidateCsv } from "@/lib/parseAndValidateCsv";
 
 export default function DashboardPage() {
+  const [showDashboard, setShowDashboard] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleFile = async (file: File) => {
+    const result = await parseAndValidateCsv(file);
+    if (result.success) {
+      setShowDashboard(true);
+    } else {
+      setError("Upload failed, please try again.");
+    }
+  };
+
+  if (showDashboard) {
+    return <MockDashboard />;
+  }
+
   return (
-    <div className="p-4">
-      <Card>
-        <CardHeader>
-          <CardTitle>Dashboard Overview</CardTitle>
-        </CardHeader>
-        <CardContent>
-          <p>Your metrics and insights will be displayed here.</p>
-        </CardContent>
-      </Card>
+    <div className="p-4 space-y-4">
+      {error && <p className="text-red-500">{error}</p>}
+      <FileUpload onFileAccepted={handleFile} />
     </div>
   );
 }

--- a/src/components/MockDashboard.tsx
+++ b/src/components/MockDashboard.tsx
@@ -1,0 +1,16 @@
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+
+export default function MockDashboard() {
+  return (
+    <div className="p-4">
+      <Card>
+        <CardHeader>
+          <CardTitle>Dashboard Overview</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <p>Your metrics and insights will be displayed here.</p>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- implement client-side dashboard logic to handle CSV uploads
- show a `MockDashboard` placeholder on success
- provide error messaging for invalid uploads

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685bf26a844c832c99d9cf6ee1205905