### PR TITLE
Improve CSV upload handling

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -12,11 +12,33 @@ export default function DashboardPage() {
   const handleFile = async (file: File) => {
     setError(null);
     const result = await parseAndValidateCsv(file);
+
     if (result.success) {
       setShowDashboard(true);
-    } else {
-      setError("Upload failed, please try again.");
+      return;
     }
+
+    switch (result.error) {
+      case "empty_file":
+        console.error("CSV upload failed: empty_file");
+        break;
+      case "missing_columns":
+        console.error(
+          "CSV upload failed: missing_columns",
+          result.details,
+        );
+        break;
+      case "unexpected_columns":
+        console.error(
+          "CSV upload failed: unexpected_columns",
+          result.details,
+        );
+        break;
+      default:
+        console.error("CSV upload failed", result);
+    }
+
+    setError("Upload failed, please try again.");
   };
 
   if (showDashboard) {


### PR DESCRIPTION
## Summary
- handle detailed CSV upload errors in `DashboardPage`

## Testing
- `npm run lint` *(fails: `next: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_685bf97686bc832c96e4c15ff5949cfe