### PR TITLE
Add UploadErrorMessage component

### DIFF
--- a/src/components/FileUpload.tsx
+++ b/src/components/FileUpload.tsx
@@ -2,6 +2,7 @@
 
 import { useState, DragEvent, ChangeEvent } from "react";
 import { Button } from "@/components/ui/button";
+import UploadErrorMessage from "./UploadErrorMessage";
 
 interface FileUploadProps {
   onFileAccepted: (file: File) => void;
@@ -81,7 +82,7 @@ export default function FileUpload({
           <Button type="button">Browse</Button>
         </label>
       </div>
-      {error && <p className="text-destructive text-sm">{error}</p>}
+      {error && <UploadErrorMessage message={error} />}
     </div>
   );
 }

--- a/src/components/UploadErrorMessage.tsx
+++ b/src/components/UploadErrorMessage.tsx
@@ -1,0 +1,28 @@
+"use client";
+
+import { useState } from "react";
+import { cn } from "@/lib/utils";
+
+interface UploadErrorMessageProps {
+  message: string;
+}
+
+export default function UploadErrorMessage({ message }: UploadErrorMessageProps) {
+  const [visible, setVisible] = useState(true);
+
+  if (!visible) return null;
+
+  return (
+    <div className={cn("text-red-500 bg-red-50 border rounded-md p-2 flex items-start gap-2")}> 
+      <span className="flex-1">{message}</span>
+      <button
+        type="button"
+        aria-label="Dismiss error"
+        className="text-red-500 hover:text-red-700"
+        onClick={() => setVisible(false)}
+      >
+        &times;
+      </button>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- create reusable `UploadErrorMessage` component
- use the new component in `FileUpload`

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_685bfa1947a8832c918f56c811da4753