### PR TITLE
Mount MetricsSummary in dashboard

### DIFF
--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -8,18 +8,17 @@ export interface DashboardProps {
 }
 
 export default function Dashboard({ metricsData, taskData }: DashboardProps) {
+  const hasMetricsData =
+    metricsData && Object.keys(metricsData.byType ?? {}).length > 0;
+
   return (
     <div className="p-4 space-y-8">
       <h1 className="text-2xl font-semibold">Project Dashboard</h1>
 
-      {metricsData && (
+      {hasMetricsData && (
         <section className="space-y-4">
           <h2 className="text-xl font-semibold">Metrics Overview</h2>
-          <MetricsSummary
-            overall={metricsData.overall}
-            byType={metricsData.byType}
-            throughput={metricsData.throughput}
-          />
+          <MetricsSummary {...metricsData} />
         </section>
       )}
 


### PR DESCRIPTION
## Summary
- mount the `MetricsSummary` component on the Dashboard
- guard against empty metrics data before rendering

## Testing
- `npm run lint` *(fails: `next` not found)*
- `pnpm install` *(fails: network access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_685c11d0b9c8832cae10b0974a2c3058