### PR TITLE
Add DashboardTaskList component and integrate

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -3,6 +3,7 @@
 import { useState } from "react";
 import FileUpload from "@/components/FileUpload";
 import Dashboard from "@/components/Dashboard";
+import type { TaskItem } from "@/components/DashboardTaskList";
 import type { MetricsSummaryProps } from "@/components/MetricsSummary";
 import {
   calculateTaskMetrics,
@@ -17,7 +18,7 @@ export default function DashboardPage() {
   const [showDashboard, setShowDashboard] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [metrics, setMetrics] = useState<MetricsSummaryProps | null>(null);
-  const [tasks, setTasks] = useState<RawTask[] | null>(null);
+  const [tasks, setTasks] = useState<TaskItem[] | null>(null);
 
   const handleFile = async (file: File) => {
     setError(null);
@@ -25,9 +26,17 @@ export default function DashboardPage() {
 
     if (result.success) {
       const rawTasks = result.data as RawTask[];
-      setTasks(rawTasks);
-
       const taskMetrics = calculateTaskMetrics(rawTasks);
+      const dashboardTasks: TaskItem[] = rawTasks.map((task, idx) => ({
+        ID: Number(task.ID),
+        Title: (task as any).Title,
+        WorkItemType: (task as any)["Work Item Type"],
+        Assignee: (task as any)["Assigned To"] ?? null,
+        CycleTimeDays: taskMetrics[idx].CycleTimeDays,
+        LeadTimeDays: taskMetrics[idx].LeadTimeDays,
+      }));
+      setTasks(dashboardTasks);
+
       const metricsSummary: MetricsSummaryProps = {
         overall: calculateOverallMetrics(taskMetrics),
         byType: aggregateMetricsByType(taskMetrics),

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -1,10 +1,12 @@
 import MetricsSummary from "@/components/MetricsSummary";
-import DashboardTaskList from "@/components/DashboardTaskList";
+import DashboardTaskList, {
+  type TaskItem,
+} from "@/components/DashboardTaskList";
 import type { MetricsSummaryProps } from "@/components/MetricsSummary";
 
 export interface DashboardProps {
   metricsData?: MetricsSummaryProps | null;
-  taskData?: any[] | null;
+  taskData?: TaskItem[] | null;
 }
 
 export default function Dashboard({ metricsData, taskData }: DashboardProps) {
@@ -26,7 +28,7 @@ export default function Dashboard({ metricsData, taskData }: DashboardProps) {
       {taskData && taskData.length > 0 && (
         <section className="space-y-4">
           <h2 className="text-xl font-semibold">Task List</h2>
-          <DashboardTaskList tasks={taskData} />
+          <DashboardTaskList taskData={taskData} />
         </section>
       )}
     </div>

--- a/src/components/DashboardTaskList.tsx
+++ b/src/components/DashboardTaskList.tsx
@@ -8,16 +8,26 @@ import {
 } from "@/components/ui/table";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 
-export interface DashboardTaskListProps {
-  tasks: Array<{
-    ID: number | string;
-    Title: string;
-    State: string;
-    [key: string]: any;
-  }>;
+export interface TaskItem {
+  ID: number;
+  Title: string;
+  WorkItemType: string;
+  Assignee: string | null;
+  CycleTimeDays?: number;
+  LeadTimeDays?: number;
 }
 
-export default function DashboardTaskList({ tasks }: DashboardTaskListProps) {
+export interface DashboardTaskListProps {
+  taskData: TaskItem[];
+}
+
+export default function DashboardTaskList({
+  taskData,
+}: DashboardTaskListProps) {
+  if (!taskData || taskData.length === 0) {
+    return null;
+  }
+
   return (
     <Card>
       <CardHeader>
@@ -27,19 +37,29 @@ export default function DashboardTaskList({ tasks }: DashboardTaskListProps) {
         <Table>
           <TableHeader>
             <TableRow>
-              <TableHead>ID</TableHead>
+              <TableHead>Task ID</TableHead>
               <TableHead>Title</TableHead>
-              <TableHead>Type</TableHead>
-              <TableHead>State</TableHead>
+              <TableHead>Work Item Type</TableHead>
+              <TableHead>Assignee</TableHead>
+              <TableHead>Cycle Time (days)</TableHead>
+              <TableHead>Lead Time (days)</TableHead>
+              <TableHead>RCA Indicator</TableHead>
             </TableRow>
           </TableHeader>
           <TableBody>
-            {tasks.map((task) => (
+            {taskData.map((task) => (
               <TableRow key={task.ID}>
                 <TableCell>{task.ID}</TableCell>
                 <TableCell>{task.Title}</TableCell>
-                <TableCell>{task["Work Item Type"]}</TableCell>
-                <TableCell>{task.State}</TableCell>
+                <TableCell>{task.WorkItemType}</TableCell>
+                <TableCell>{task.Assignee ?? "-"}</TableCell>
+                <TableCell>
+                  {typeof task.CycleTimeDays === "number" ? task.CycleTimeDays : "-"}
+                </TableCell>
+                <TableCell>
+                  {typeof task.LeadTimeDays === "number" ? task.LeadTimeDays : "-"}
+                </TableCell>
+                <TableCell></TableCell>
               </TableRow>
             ))}
           </TableBody>


### PR DESCRIPTION
## Summary
- implement `DashboardTaskList` component to show task details in a table
- update `Dashboard` to use new component and types
- compute task list with metrics in `page.tsx`

## Testing
- `npm run lint` *(fails: `next: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_685c12254440832c9c8381ccba1a77aa