### PR TITLE
Add RCA settings context

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import "./globals.css";
 import NavBar from "@/components/layout/NavBar";
+import { SettingsProvider } from "@/context/SettingsContext";
 
 export const metadata: Metadata = {
   title: "DevOps Insights",
@@ -15,8 +16,10 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body className="min-h-screen">
-        <NavBar />
-        {children}
+        <SettingsProvider>
+          <NavBar />
+          {children}
+        </SettingsProvider>
       </body>
     </html>
   );

--- a/src/components/DashboardTaskList.tsx
+++ b/src/components/DashboardTaskList.tsx
@@ -9,6 +9,7 @@ import {
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import RCAIndicator from "@/components/RCAIndicator";
 import { checkRCAIndicator } from "@/lib/checkRCAIndicator";
+import { useSettings } from "@/context/SettingsContext";
 
 export interface TaskItem {
   ID: number;
@@ -29,6 +30,8 @@ export default function DashboardTaskList({
   if (!taskData || taskData.length === 0) {
     return null;
   }
+
+  const { rcaDeviationPercentage } = useSettings();
 
   return (
     <Card>
@@ -51,7 +54,11 @@ export default function DashboardTaskList({
             {taskData.map((task) => {
               const isRCA =
                 typeof task.CycleTimeDays === "number" &&
-                checkRCAIndicator(task.CycleTimeDays, "M");
+                checkRCAIndicator(
+                  task.CycleTimeDays,
+                  "M",
+                  rcaDeviationPercentage,
+                );
 
               return (
                 <TableRow key={task.ID}>

--- a/src/components/ThresholdForm.tsx
+++ b/src/components/ThresholdForm.tsx
@@ -5,6 +5,7 @@ import { zodResolver } from "@hookform/resolvers/zod";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { z } from "zod";
+import { useSettings } from "@/context/SettingsContext";
 
 const schema = z.object({
   XS: z.number().positive(),
@@ -21,6 +22,7 @@ const schema = z.object({
 type Thresholds = z.infer<typeof schema>;
 
 export default function ThresholdForm() {
+  const { rcaDeviationPercentage, setRcaDeviationPercentage } = useSettings();
   const {
     register,
     handleSubmit,
@@ -33,11 +35,12 @@ export default function ThresholdForm() {
       M: 3,
       L: 5,
       XL: 8,
-      rcaDeviationPercentage: 20,
+      rcaDeviationPercentage,
     },
   });
 
   const onSubmit = (data: Thresholds) => {
+    setRcaDeviationPercentage(data.rcaDeviationPercentage);
     // TODO: replace with API call
     console.log("Saving settings:", data);
   };

--- a/src/context/SettingsContext.tsx
+++ b/src/context/SettingsContext.tsx
@@ -1,0 +1,28 @@
+"use client";
+
+import { createContext, useContext, useState } from "react";
+
+interface SettingsContextValue {
+  rcaDeviationPercentage: number;
+  setRcaDeviationPercentage: (value: number) => void;
+}
+
+const SettingsContext = createContext<SettingsContextValue | undefined>(undefined);
+
+export function SettingsProvider({ children }: { children: React.ReactNode }) {
+  const [rcaDeviationPercentage, setRcaDeviationPercentage] = useState(20);
+
+  return (
+    <SettingsContext.Provider value={{ rcaDeviationPercentage, setRcaDeviationPercentage }}>
+      {children}
+    </SettingsContext.Provider>
+  );
+}
+
+export function useSettings() {
+  const context = useContext(SettingsContext);
+  if (!context) {
+    throw new Error("useSettings must be used within a SettingsProvider");
+  }
+  return context;
+}


### PR DESCRIPTION
## Summary
- add `SettingsContext` for deviation percentage state
- wrap app layout with context provider
- update dashboard task list to use global deviation setting
- allow ThresholdForm to update the global setting

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c180c8c28832ca1c80a0ba920225f