### PR TITLE
Add persistent threshold config hook

### DIFF
--- a/src/hooks/usePersistentThresholdConfig.ts
+++ b/src/hooks/usePersistentThresholdConfig.ts
@@ -1,0 +1,43 @@
+import { useEffect, useState } from "react";
+import {
+  defaultThresholdConfig,
+  type ThresholdConfig,
+} from "@/lib/defaultThresholdConfig";
+
+const STORAGE_KEY = "thresholdConfig";
+
+export function usePersistentThresholdConfig() {
+  const [config, setConfig] = useState<ThresholdConfig>(() => {
+    if (typeof window !== "undefined") {
+      try {
+        const stored = localStorage.getItem(STORAGE_KEY);
+        if (stored) {
+          return JSON.parse(stored) as ThresholdConfig;
+        }
+      } catch {
+        // ignore JSON parse errors
+      }
+    }
+    return defaultThresholdConfig;
+  });
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    try {
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(config));
+    } catch {
+      // ignore write errors
+    }
+  }, [config]);
+
+  const getConfig = () => config;
+
+  const updateConfig = (newConfig: ThresholdConfig) => {
+    setConfig(newConfig);
+  };
+
+  return {
+    getConfig,
+    updateConfig,
+  };
+}


### PR DESCRIPTION
## Summary
- implement `usePersistentThresholdConfig` for storing threshold settings in localStorage

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c1ce17630832c9a43f670e34ea586