### PR TITLE
Integrate persisted threshold settings

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -3,44 +3,20 @@
 import { useState } from "react";
 import FileUpload from "@/components/FileUpload";
 import Dashboard from "@/components/Dashboard";
-import type { TaskItem } from "@/components/DashboardTaskList";
-import type { MetricsSummaryProps } from "@/components/MetricsSummary";
-import { calculateTaskMetrics, type RawTask } from "@/lib/calculateTaskMetrics";
-import { calculateOverallMetrics } from "@/lib/calculateOverallMetrics";
-import { aggregateMetricsByType } from "@/lib/aggregateMetricsByType";
-import { calculateThroughputMetrics } from "@/lib/calculateThroughputMetrics";
 import { parseAndValidateCsv } from "@/lib/parseAndValidateCsv";
+import type { RawTask } from "@/lib/calculateTaskMetrics";
 
 export default function DashboardPage() {
   const [showDashboard, setShowDashboard] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const [metrics, setMetrics] = useState<MetricsSummaryProps | null>(null);
-  const [tasks, setTasks] = useState<TaskItem[] | null>(null);
+  const [rawTasks, setRawTasks] = useState<RawTask[] | null>(null);
 
   const handleFile = async (file: File) => {
     setError(null);
     const result = await parseAndValidateCsv(file);
 
     if (result.success) {
-      const rawTasks = result.data as RawTask[];
-      const taskMetrics = calculateTaskMetrics(rawTasks);
-      const dashboardTasks: TaskItem[] = rawTasks.map((task, idx) => ({
-        ID: Number(task.ID),
-        Title: (task as any).Title,
-        WorkItemType: (task as any)["Work Item Type"],
-        Assignee: (task as any)["Assigned To"] ?? null,
-        CycleTimeDays: taskMetrics[idx].CycleTimeDays,
-        LeadTimeDays: taskMetrics[idx].LeadTimeDays,
-      }));
-      setTasks(dashboardTasks);
-
-      const metricsSummary: MetricsSummaryProps = {
-        overall: calculateOverallMetrics(taskMetrics),
-        byType: aggregateMetricsByType(taskMetrics),
-        throughput: calculateThroughputMetrics(rawTasks, new Date()),
-      };
-      setMetrics(metricsSummary);
-
+      setRawTasks(result.data as RawTask[]);
       setShowDashboard(true);
       return;
     }
@@ -62,8 +38,8 @@ export default function DashboardPage() {
     setError("Upload failed, please try again.");
   };
 
-  if (showDashboard) {
-    return <Dashboard metricsData={metrics} taskData={tasks ?? []} />;
+  if (showDashboard && rawTasks) {
+    return <Dashboard rawTasks={rawTasks} />;
   }
 
   return (

--- a/src/components/DashboardTaskList.tsx
+++ b/src/components/DashboardTaskList.tsx
@@ -31,7 +31,7 @@ export default function DashboardTaskList({
     return null;
   }
 
-  const { rcaDeviationPercentage } = useSettings();
+  const { config } = useSettings();
 
   return (
     <Card>
@@ -54,11 +54,7 @@ export default function DashboardTaskList({
             {taskData.map((task) => {
               const isRCA =
                 typeof task.CycleTimeDays === "number" &&
-                checkRCAIndicator(
-                  task.CycleTimeDays,
-                  "M",
-                  rcaDeviationPercentage,
-                );
+                checkRCAIndicator(task.CycleTimeDays, "M", config);
 
               return (
                 <TableRow key={task.ID}>

--- a/src/components/ThresholdForm.tsx
+++ b/src/components/ThresholdForm.tsx
@@ -1,13 +1,11 @@
 "use client";
 
-import { useEffect } from "react";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { z } from "zod";
 import { useSettings } from "@/context/SettingsContext";
-import { usePersistentThresholdConfig } from "@/hooks/usePersistentThresholdConfig";
 
 const rangeSchema = z
   .object({
@@ -37,9 +35,7 @@ const schema = z.object({
 type Thresholds = z.infer<typeof schema>;
 
 export default function ThresholdForm() {
-  const { setRcaDeviationPercentage } = useSettings();
-  const { getConfig, updateConfig } = usePersistentThresholdConfig();
-  const defaultConfig = getConfig();
+  const { config: defaultConfig, updateConfig } = useSettings();
   const {
     register,
     handleSubmit,
@@ -49,12 +45,7 @@ export default function ThresholdForm() {
     defaultValues: defaultConfig,
   });
 
-  useEffect(() => {
-    setRcaDeviationPercentage(defaultConfig.rcaDeviationPercentage);
-  }, [defaultConfig.rcaDeviationPercentage, setRcaDeviationPercentage]);
-
   const onSubmit = (data: Thresholds) => {
-    setRcaDeviationPercentage(data.rcaDeviationPercentage);
     updateConfig(data);
   };
 

--- a/src/context/SettingsContext.tsx
+++ b/src/context/SettingsContext.tsx
@@ -1,19 +1,22 @@
 "use client";
 
-import { createContext, useContext, useState } from "react";
+import { createContext, useContext } from "react";
+import { usePersistentThresholdConfig } from "@/hooks/usePersistentThresholdConfig";
+import type { ThresholdConfig } from "@/lib/defaultThresholdConfig";
 
 interface SettingsContextValue {
-  rcaDeviationPercentage: number;
-  setRcaDeviationPercentage: (value: number) => void;
+  config: ThresholdConfig;
+  updateConfig: (value: ThresholdConfig) => void;
 }
 
 const SettingsContext = createContext<SettingsContextValue | undefined>(undefined);
 
 export function SettingsProvider({ children }: { children: React.ReactNode }) {
-  const [rcaDeviationPercentage, setRcaDeviationPercentage] = useState(20);
+  const { getConfig, updateConfig } = usePersistentThresholdConfig();
+  const config = getConfig();
 
   return (
-    <SettingsContext.Provider value={{ rcaDeviationPercentage, setRcaDeviationPercentage }}>
+    <SettingsContext.Provider value={{ config, updateConfig }}>
       {children}
     </SettingsContext.Provider>
   );

--- a/src/lib/checkRCAIndicator.ts
+++ b/src/lib/checkRCAIndicator.ts
@@ -1,12 +1,9 @@
-export const CycleTimeThresholds = {
-  XS: [1, 2],
-  S: [2, 4],
-  M: [3, 6],
-  L: [5, 10],
-  XL: [8, 15],
-} as const;
+import {
+  defaultThresholdConfig,
+  type ThresholdConfig,
+} from "@/lib/defaultThresholdConfig";
 
-export type TShirtSize = keyof typeof CycleTimeThresholds;
+export type TShirtSize = keyof ThresholdConfig["thresholds"];
 
 /**
  * Determines if an RCA indicator should be shown based on the cycle time and
@@ -14,17 +11,18 @@ export type TShirtSize = keyof typeof CycleTimeThresholds;
  *
  * @param cycleTimeDays - The actual cycle time in days.
  * @param tShirtSize - The T‑shirt size to compare against.
- * @param deviationPercentage - Allowed deviation percentage from the range.
+ * @param config - Threshold configuration containing ranges and deviation.
  * @returns True if the cycle time deviates outside the allowed range.
  */
 export function checkRCAIndicator(
   cycleTimeDays: number,
   tShirtSize: TShirtSize,
-  deviationPercentage = 20,
+  config: ThresholdConfig = defaultThresholdConfig,
 ): boolean {
-  const [min, max] = CycleTimeThresholds[tShirtSize];
-  const factor = deviationPercentage / 100;
-  const lowerBound = min * (1 - factor);
-  const upperBound = max * (1 + factor);
+  const { thresholds, rcaDeviationPercentage } = config;
+  const { lower, upper } = thresholds[tShirtSize];
+  const factor = rcaDeviationPercentage / 100;
+  const lowerBound = lower * (1 - factor);
+  const upperBound = upper * (1 + factor);
   return cycleTimeDays < lowerBound || cycleTimeDays > upperBound;
 }


### PR DESCRIPTION
## Summary
- make RCA threshold check read from persisted configuration
- expose threshold config via `SettingsContext`
- use new settings in dashboard and threshold form

## Testing
- `npm run lint` *(fails: `next: not found`)*
- `pnpm lint` *(fails: `next: not found`)*
- `npx tsc --noEmit` *(fails: cannot find module 'next')*

------
https://chatgpt.com/codex/tasks/task_e_685c1eb8cfe8832ca869b939bfa47727