### PR TITLE
Add classifyTasksByStatus utility

### DIFF
--- a/src/lib/classifyTasksByStatus.ts
+++ b/src/lib/classifyTasksByStatus.ts
@@ -1,0 +1,33 @@
+export interface Task {
+  ID: number | string;
+  Title: string;
+  WorkItemType: string;
+  Assignee?: string | null;
+  CreatedDate: string;
+  ActivatedDate?: string;
+  ClosedDate?: string;
+}
+
+export interface ClassifiedTasks {
+  completedTasks: Task[];
+  inProgressTasks: Task[];
+  notStartedTasks: Task[];
+}
+
+export function classifyTasksByStatus(tasks: Task[]): ClassifiedTasks {
+  const completedTasks: Task[] = [];
+  const inProgressTasks: Task[] = [];
+  const notStartedTasks: Task[] = [];
+
+  for (const task of tasks) {
+    if (task.ClosedDate) {
+      completedTasks.push(task);
+    } else if (task.ActivatedDate) {
+      inProgressTasks.push(task);
+    } else {
+      notStartedTasks.push(task);
+    }
+  }
+
+  return { completedTasks, inProgressTasks, notStartedTasks };
+}


### PR DESCRIPTION
## Summary
- implement `classifyTasksByStatus` to group tasks by completion state

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c5150ebcc832c85f6971d0da07e47