### PR TITLE
Refactor threshold configuration

### DIFF
--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -18,6 +18,7 @@ import { aggregateMetricsByType } from "@/lib/aggregateMetricsByType";
 import { calculateThroughputMetrics } from "@/lib/calculateThroughputMetrics";
 import type { SortDirection } from "@/lib/sortTasks";
 import { classifyTasksByStatus } from "@/lib/classifyTasksByStatus";
+import { calculateCycleTimePercentage } from "@/lib/calculateCycleTimePercentage";
 import { usePersistentTaskTableVisibility } from "@/hooks/usePersistentTaskTableVisibility";
 
 export interface DashboardProps {
@@ -45,6 +46,7 @@ export default function Dashboard({ rawTasks }: DashboardProps) {
         CreatedDate: (t as any)["Created Date"],
         ActivatedDate: (t as any)["Activated Date"] ?? undefined,
         ClosedDate: (t as any)["Closed Date"] ?? undefined,
+        TShirtSize: (t as any).TShirtSize ?? undefined,
       })),
     [rawTasks]
   );
@@ -129,6 +131,14 @@ export default function Dashboard({ rawTasks }: DashboardProps) {
         Assignee: task.Assignee ?? null,
         CycleTimeDays: completedMetrics[idx].CycleTimeDays,
         LeadTimeDays: completedMetrics[idx].LeadTimeDays,
+        TShirtSize: task.TShirtSize,
+        CycleTimePercentage:
+          typeof completedMetrics[idx].CycleTimeDays === "number"
+            ? calculateCycleTimePercentage(
+                completedMetrics[idx].CycleTimeDays!,
+                task.TShirtSize,
+              )
+            : undefined,
         ClosedDate: task.ClosedDate ?? undefined,
       })),
     [filteredCompleted, completedMetrics]
@@ -142,6 +152,7 @@ export default function Dashboard({ rawTasks }: DashboardProps) {
         WorkItemType: task.WorkItemType,
         Assignee: task.Assignee ?? null,
         ActivatedDate: task.ActivatedDate,
+        TShirtSize: task.TShirtSize,
       })),
     [inProgressTasks]
   );
@@ -154,6 +165,7 @@ export default function Dashboard({ rawTasks }: DashboardProps) {
         WorkItemType: task.WorkItemType,
         Assignee: task.Assignee ?? null,
         CreatedDate: task.CreatedDate,
+        TShirtSize: task.TShirtSize,
       })),
     [notStartedTasks]
   );

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -141,7 +141,7 @@ export default function Dashboard({ rawTasks }: DashboardProps) {
             : undefined,
         ClosedDate: task.ClosedDate ?? undefined,
       })),
-    [filteredCompleted, completedMetrics]
+    [filteredCompleted, completedMetrics, config]
   );
 
   const inProgressListData = useMemo(

--- a/src/components/DashboardTaskList.tsx
+++ b/src/components/DashboardTaskList.tsx
@@ -7,9 +7,8 @@ import {
   TableCell,
 } from "@/components/ui/table";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import RCAIndicator from "@/components/RCAIndicator";
 import SortableTableHeader from "@/components/SortableTableHeader";
-import { checkRCAIndicator } from "@/lib/checkRCAIndicator";
+import { getCycleTimePercentageColor } from "@/lib/getCycleTimePercentageColor";
 import { filterTasksByDateRange, type DateRangeOption } from "@/lib/filterTasksByDateRange";
 import { sortTasks, type SortDirection } from "@/lib/sortTasks";
 import { useSettings } from "@/context/SettingsContext";
@@ -22,6 +21,8 @@ export interface TaskItem {
   Assignee: string | null;
   CycleTimeDays?: number;
   LeadTimeDays?: number;
+  TShirtSize?: import("@/lib/checkRCAIndicator").TShirtSize;
+  CycleTimePercentage?: number | "No reference";
   ClosedDate?: string;
 }
 
@@ -78,30 +79,39 @@ export default function DashboardTaskList({
             {sortedCompleted.length > 0 && (
               <>
                 <TableRow className="bg-muted/50">
-                  <TableCell colSpan={7} className="font-semibold">
+                  <TableCell colSpan={8} className="font-semibold">
                     Completed
                   </TableCell>
                 </TableRow>
                 {sortedCompleted.map((task) => {
-                  const isRCA =
-                    typeof task.CycleTimeDays === "number" &&
-                    checkRCAIndicator(task.CycleTimeDays, "M", config);
-
                   return (
                     <TableRow key={`c-${task.ID}`}>
                       <TableCell>{task.ID}</TableCell>
-                      <TableCell>
-                        <div className="flex items-center gap-2">
-                          {task.Title}
-                          <RCAIndicator isRCA={isRCA} />
-                        </div>
-                      </TableCell>
+                      <TableCell>{task.Title}</TableCell>
                       <TableCell>{task.WorkItemType}</TableCell>
                       <TableCell>{task.Assignee ?? "-"}</TableCell>
                       <TableCell>
                         {typeof task.CycleTimeDays === "number"
                           ? task.CycleTimeDays
                           : "-"}
+                      </TableCell>
+                      <TableCell>
+                        {task.CycleTimePercentage !== undefined ? (
+                          <span
+                            className={(() => {
+                              const color = getCycleTimePercentageColor(
+                                task.CycleTimePercentage,
+                                config.rcaDeviationPercentage,
+                              );
+                              if (color === "black") return "text-black";
+                              return `text-${color}-500`;
+                            })()}
+                          >
+                            {task.CycleTimePercentage}
+                          </span>
+                        ) : (
+                          "-"
+                        )}
                       </TableCell>
                       <TableCell>
                         {typeof task.LeadTimeDays === "number"
@@ -118,30 +128,39 @@ export default function DashboardTaskList({
             {sortedInProgress.length > 0 && (
               <>
                 <TableRow className="bg-muted/50">
-                  <TableCell colSpan={7} className="font-semibold">
+                  <TableCell colSpan={8} className="font-semibold">
                     In Progress
                   </TableCell>
                 </TableRow>
                 {sortedInProgress.map((task) => {
-                  const isRCA =
-                    typeof task.CycleTimeDays === "number" &&
-                    checkRCAIndicator(task.CycleTimeDays, "M", config);
-
                   return (
                     <TableRow key={`p-${task.ID}`}>
                       <TableCell>{task.ID}</TableCell>
-                      <TableCell>
-                        <div className="flex items-center gap-2">
-                          {task.Title}
-                          <RCAIndicator isRCA={isRCA} />
-                        </div>
-                      </TableCell>
+                      <TableCell>{task.Title}</TableCell>
                       <TableCell>{task.WorkItemType}</TableCell>
                       <TableCell>{task.Assignee ?? "-"}</TableCell>
                       <TableCell>
                         {typeof task.CycleTimeDays === "number"
                           ? task.CycleTimeDays
                           : "-"}
+                      </TableCell>
+                      <TableCell>
+                        {task.CycleTimePercentage !== undefined ? (
+                          <span
+                            className={(() => {
+                              const color = getCycleTimePercentageColor(
+                                task.CycleTimePercentage,
+                                config.rcaDeviationPercentage,
+                              );
+                              if (color === "black") return "text-black";
+                              return `text-${color}-500`;
+                            })()}
+                          >
+                            {task.CycleTimePercentage}
+                          </span>
+                        ) : (
+                          "-"
+                        )}
                       </TableCell>
                       <TableCell>
                         {typeof task.LeadTimeDays === "number"

--- a/src/components/SortableTableHeader.tsx
+++ b/src/components/SortableTableHeader.tsx
@@ -27,6 +27,7 @@ const COLUMNS: ColumnDef[] = [
   { key: "WorkItemType", label: "Work Item Type" },
   { key: "Assignee", label: "Assignee" },
   { key: "CycleTimeDays", label: "Cycle Time" },
+  { key: "CycleTimePercentage", label: "Cycle Time %" },
   { key: "LeadTimeDays", label: "Lead Time" },
   { key: "ClosedDate", label: "Closed Date" },
 ];

--- a/src/components/ThresholdForm.tsx
+++ b/src/components/ThresholdForm.tsx
@@ -7,23 +7,13 @@ import { Input } from "@/components/ui/input";
 import { z } from "zod";
 import { useSettings } from "@/context/SettingsContext";
 
-const rangeSchema = z
-  .object({
-    lower: z.number().positive(),
-    upper: z.number().positive(),
-  })
-  .refine((v) => v.lower < v.upper, {
-    message: "Lower must be < upper",
-    path: ["upper"],
-  });
-
 const schema = z.object({
   thresholds: z.object({
-    XS: rangeSchema,
-    S: rangeSchema,
-    M: rangeSchema,
-    L: rangeSchema,
-    XL: rangeSchema,
+    XS: z.number().positive(),
+    S: z.number().positive(),
+    M: z.number().positive(),
+    L: z.number().positive(),
+    XL: z.number().positive(),
   }),
   rcaDeviationPercentage: z
     .number()
@@ -57,30 +47,15 @@ export default function ThresholdForm() {
       {["XS", "S", "M", "L", "XL"].map((size) => (
         <div key={size}>
           <label className="font-medium block">{size} Threshold (days)</label>
-          <div className="flex gap-2">
-            <Input
-              type="number"
-              placeholder="Lower"
-              {...register(`thresholds.${size}.lower` as const, {
-                valueAsNumber: true,
-              })}
-            />
-            <Input
-              type="number"
-              placeholder="Upper"
-              {...register(`thresholds.${size}.upper` as const, {
-                valueAsNumber: true,
-              })}
-            />
-          </div>
-          {errors.thresholds?.[size]?.lower && (
+          <Input
+            type="number"
+            {...register(`thresholds.${size}` as const, {
+              valueAsNumber: true,
+            })}
+          />
+          {errors.thresholds?.[size] && (
             <span className="text-red-500 text-sm">
-              {errors.thresholds[size]?.lower?.message as string}
-            </span>
-          )}
-          {errors.thresholds?.[size]?.upper && (
-            <span className="text-red-500 text-sm">
-              {errors.thresholds[size]?.upper?.message as string}
+              {errors.thresholds[size]?.message as string}
             </span>
           )}
         </div>

--- a/src/components/ThresholdForm.tsx
+++ b/src/components/ThresholdForm.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useForm } from "react-hook-form";
+import { useEffect } from "react";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -9,11 +10,11 @@ import { useSettings } from "@/context/SettingsContext";
 
 const schema = z.object({
   thresholds: z.object({
-    XS: z.number().positive(),
-    S: z.number().positive(),
-    M: z.number().positive(),
-    L: z.number().positive(),
-    XL: z.number().positive(),
+    XS: z.number().int().positive(),
+    S: z.number().int().positive(),
+    M: z.number().int().positive(),
+    L: z.number().int().positive(),
+    XL: z.number().int().positive(),
   }),
   rcaDeviationPercentage: z
     .number()
@@ -29,11 +30,17 @@ export default function ThresholdForm() {
   const {
     register,
     handleSubmit,
+    reset,
     formState: { errors },
   } = useForm<Thresholds>({
     resolver: zodResolver(schema),
     defaultValues: defaultConfig,
   });
+
+  // sync form when persisted configuration changes
+  useEffect(() => {
+    reset(defaultConfig);
+  }, [defaultConfig, reset]);
 
   const onSubmit = (data: Thresholds) => {
     updateConfig(data);
@@ -49,6 +56,8 @@ export default function ThresholdForm() {
           <label className="font-medium block">{size} Threshold (days)</label>
           <Input
             type="number"
+            min={1}
+            step={1}
             {...register(`thresholds.${size}` as const, {
               valueAsNumber: true,
             })}
@@ -64,6 +73,8 @@ export default function ThresholdForm() {
         <label>RCA Deviation Percentage (%)</label>
         <Input
           type="number"
+          min={5}
+          step={1}
           {...register("rcaDeviationPercentage", { valueAsNumber: true })}
         />
         {errors.rcaDeviationPercentage && (

--- a/src/hooks/usePersistentThresholdConfig.ts
+++ b/src/hooks/usePersistentThresholdConfig.ts
@@ -1,24 +1,24 @@
 import { useEffect, useState } from "react";
-import {
-  defaultThresholdConfig,
-  type ThresholdConfig,
+import { ThresholdConfig } from "@/lib/defaultThresholdConfig";
+import type {
+  ThresholdConfig as ThresholdConfigType,
 } from "@/lib/defaultThresholdConfig";
 
 const STORAGE_KEY = "thresholdConfig";
 
 export function usePersistentThresholdConfig() {
-  const [config, setConfig] = useState<ThresholdConfig>(() => {
+  const [config, setConfig] = useState<ThresholdConfigType>(() => {
     if (typeof window !== "undefined") {
       try {
         const stored = localStorage.getItem(STORAGE_KEY);
         if (stored) {
-          return JSON.parse(stored) as ThresholdConfig;
+          return JSON.parse(stored) as ThresholdConfigType;
         }
       } catch {
         // ignore JSON parse errors
       }
     }
-    return defaultThresholdConfig;
+    return ThresholdConfig;
   });
 
   useEffect(() => {
@@ -32,7 +32,7 @@ export function usePersistentThresholdConfig() {
 
   const getConfig = () => config;
 
-  const updateConfig = (newConfig: ThresholdConfig) => {
+  const updateConfig = (newConfig: ThresholdConfigType) => {
     setConfig(newConfig);
   };
 

--- a/src/hooks/usePersistentThresholdConfig.ts
+++ b/src/hooks/usePersistentThresholdConfig.ts
@@ -7,19 +7,20 @@ import type {
 const STORAGE_KEY = "thresholdConfig";
 
 export function usePersistentThresholdConfig() {
-  const [config, setConfig] = useState<ThresholdConfigType>(() => {
-    if (typeof window !== "undefined") {
-      try {
-        const stored = localStorage.getItem(STORAGE_KEY);
-        if (stored) {
-          return JSON.parse(stored) as ThresholdConfigType;
-        }
-      } catch {
-        // ignore JSON parse errors
+  const [config, setConfig] = useState<ThresholdConfigType>(ThresholdConfig);
+
+  // Load any previously stored configuration on mount
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    try {
+      const stored = localStorage.getItem(STORAGE_KEY);
+      if (stored) {
+        setConfig(JSON.parse(stored) as ThresholdConfigType);
       }
+    } catch {
+      // ignore JSON parse errors
     }
-    return ThresholdConfig;
-  });
+  }, []);
 
   useEffect(() => {
     if (typeof window === "undefined") return;
@@ -34,6 +35,13 @@ export function usePersistentThresholdConfig() {
 
   const updateConfig = (newConfig: ThresholdConfigType) => {
     setConfig(newConfig);
+    if (typeof window !== "undefined") {
+      try {
+        localStorage.setItem(STORAGE_KEY, JSON.stringify(newConfig));
+      } catch {
+        // ignore write errors
+      }
+    }
   };
 
   return {

--- a/src/lib/calculateCycleTimePercentage.ts
+++ b/src/lib/calculateCycleTimePercentage.ts
@@ -1,0 +1,28 @@
+import { ThresholdConfig } from "@/lib/defaultThresholdConfig";
+import type { TShirtSize } from "@/lib/checkRCAIndicator";
+
+/**
+ * Calculate the percentage of the cycle time relative to the expected threshold
+ * for a given T‑shirt size.
+ *
+ * @param taskCycleTimeDays - The actual cycle time for the task in days.
+ * @param tshirtSize - The T‑shirt size to use for reference.
+ * @returns The cycle time percentage rounded to one decimal place or
+ *          "No reference" when the size is not provided.
+ */
+export function calculateCycleTimePercentage(
+  taskCycleTimeDays: number,
+  tshirtSize?: TShirtSize,
+): number | "No reference" {
+  if (!tshirtSize) {
+    return "No reference";
+  }
+
+  const thresholdDays = ThresholdConfig.thresholds[tshirtSize];
+  if (!thresholdDays) {
+    return "No reference";
+  }
+
+  const percentage = (taskCycleTimeDays / thresholdDays) * 100;
+  return Number(percentage.toFixed(1));
+}

--- a/src/lib/calculateTaskMetrics.ts
+++ b/src/lib/calculateTaskMetrics.ts
@@ -6,6 +6,7 @@ export interface RawTask {
   CreatedDate: string;
   ActivatedDate?: string;
   "Closed Date"?: string;
+  TShirtSize?: import("./checkRCAIndicator").TShirtSize;
 }
 
 export interface TaskMetrics {

--- a/src/lib/checkRCAIndicator.ts
+++ b/src/lib/checkRCAIndicator.ts
@@ -1,9 +1,9 @@
-import {
-  defaultThresholdConfig,
-  type ThresholdConfig,
+import { ThresholdConfig } from "@/lib/defaultThresholdConfig";
+import type {
+  ThresholdConfig as ThresholdConfigType,
 } from "@/lib/defaultThresholdConfig";
 
-export type TShirtSize = keyof ThresholdConfig["thresholds"];
+export type TShirtSize = keyof ThresholdConfigType["thresholds"];
 
 /**
  * Determines if an RCA indicator should be shown based on the cycle time and
@@ -17,12 +17,12 @@ export type TShirtSize = keyof ThresholdConfig["thresholds"];
 export function checkRCAIndicator(
   cycleTimeDays: number,
   tShirtSize: TShirtSize,
-  config: ThresholdConfig = defaultThresholdConfig,
+  config: ThresholdConfigType = ThresholdConfig,
 ): boolean {
   const { thresholds, rcaDeviationPercentage } = config;
-  const { lower, upper } = thresholds[tShirtSize];
+  const expected = thresholds[tShirtSize];
   const factor = rcaDeviationPercentage / 100;
-  const lowerBound = lower * (1 - factor);
-  const upperBound = upper * (1 + factor);
+  const lowerBound = expected * (1 - factor);
+  const upperBound = expected * (1 + factor);
   return cycleTimeDays < lowerBound || cycleTimeDays > upperBound;
 }

--- a/src/lib/classifyTasksByStatus.ts
+++ b/src/lib/classifyTasksByStatus.ts
@@ -3,6 +3,7 @@ export interface Task {
   Title: string;
   WorkItemType: string;
   Assignee?: string | null;
+  TShirtSize?: import("./checkRCAIndicator").TShirtSize;
   CreatedDate: string;
   ActivatedDate?: string;
   ClosedDate?: string;

--- a/src/lib/defaultThresholdConfig.ts
+++ b/src/lib/defaultThresholdConfig.ts
@@ -1,12 +1,12 @@
-export const defaultThresholdConfig = {
+export const ThresholdConfig = {
   thresholds: {
-    XS: { lower: 1, upper: 2 },
-    S: { lower: 2, upper: 4 },
-    M: { lower: 3, upper: 6 },
-    L: { lower: 5, upper: 10 },
-    XL: { lower: 8, upper: 15 },
+    XS: 2,
+    S: 7,
+    M: 14,
+    L: 30,
+    XL: 60,
   },
   rcaDeviationPercentage: 20,
 };
 
-export type ThresholdConfig = typeof defaultThresholdConfig;
+export type ThresholdConfig = typeof ThresholdConfig;

--- a/src/lib/getCycleTimePercentageColor.ts
+++ b/src/lib/getCycleTimePercentageColor.ts
@@ -1,0 +1,29 @@
+
+/**
+ * Determine a color to display for the given cycle time percentage.
+ *
+ * @param percentage - The cycle time as a percentage of the threshold.
+ * @param deviationPercentage - Allowed deviation from the 100% reference.
+ * @returns "green", "black", or "red" based on the deviation rules.
+ */
+export function getCycleTimePercentageColor(
+  percentage: number | "No reference",
+  deviationPercentage: number,
+): "green" | "black" | "red" {
+  if (percentage === "No reference") {
+    return "black";
+  }
+
+  const lowerBound = 100 - deviationPercentage;
+  const upperBound = 100 + deviationPercentage;
+
+  if (percentage <= lowerBound) {
+    return "green";
+  }
+
+  if (percentage >= upperBound) {
+    return "red";
+  }
+
+  return "black";
+}

--- a/src/lib/sortTasks.ts
+++ b/src/lib/sortTasks.ts
@@ -10,6 +10,7 @@ function getComparableValue(task: GenericTask, key: string): number | string | D
   switch (key) {
     case "ID":
     case "CycleTimeDays":
+    case "CycleTimePercentage":
     case "LeadTimeDays":
       if (value === undefined || value === null || value === "") return null;
       const num = typeof value === "number" ? value : Number(value);


### PR DESCRIPTION
## Summary
- replace cycle time ranges with a numeric `ThresholdConfig`
- adapt RCA indicator and settings logic to new config
- simplify ThresholdForm to edit single values

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ced672e44832ca9fb2e6a0ac7e854